### PR TITLE
Add fallback to non-SSL connections when certificates are missing

### DIFF
--- a/Libraries/ClientApp/Client.cs
+++ b/Libraries/ClientApp/Client.cs
@@ -58,20 +58,53 @@ public class Client : IAsyncDisposable
         udp.Bind(new IPEndPoint(IPAddress.Any, 0));
 
         var net = new NetworkStream(socket, ownsSocket: true);
-        var ssl = new SslStream(net, leaveInnerStreamOpen: false,
-            userCertificateValidationCallback: (_, __, ___, ____) => true // DEV ONLY
-        );
-        await ssl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+        Stream stream = net;
+
+        try
         {
-            TargetHost = "localhost",
-            EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
-            CertificateRevocationCheckMode = X509RevocationMode.NoCheck
-        });
+            var ssl = new SslStream(net, leaveInnerStreamOpen: false,
+                userCertificateValidationCallback: (_, __, ___, ____) => true // DEV ONLY
+            );
+
+            await ssl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+            {
+                TargetHost = "localhost",
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                CertificateRevocationCheckMode = X509RevocationMode.NoCheck
+            });
+
+            stream = ssl;
+        }
+        catch (AuthenticationException)
+        {
+            Notification?.Invoke(NotificationType.Warning, "SSL negotiation failed. Falling back to unencrypted connection.");
+
+            try { stream.Dispose(); } catch { }
+            try { socket.Dispose(); } catch { }
+
+            socket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            await socket.ConnectAsync(new IPEndPoint(ip, port));
+            net = new NetworkStream(socket, ownsSocket: true);
+            stream = net;
+        }
+        catch (IOException)
+        {
+            Notification?.Invoke(NotificationType.Warning, "SSL negotiation failed due to IO error. Falling back to unencrypted connection.");
+
+            try { stream.Dispose(); } catch { }
+            try { socket.Dispose(); } catch { }
+
+            socket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            await socket.ConnectAsync(new IPEndPoint(ip, port));
+            net = new NetworkStream(socket, ownsSocket: true);
+            stream = net;
+        }
+
         //Store it in a global so we can dispose it later
-        _stream = ssl;
+        _stream = stream;
         Name = name;
 
-        _ = Task.Run(() => ReceiveLoopAsync(ssl));
+        _ = Task.Run(() => ReceiveLoopAsync(stream));
         _ = Task.Run(() => UdpReceiveLoopAsync(udp));
 
         if (createUser)
@@ -82,10 +115,10 @@ public class Client : IAsyncDisposable
                 Headers = new Dictionary<string, string> { { "Type", "AuthCodeRequest" } },
                 Payload = Array.Empty<byte>()
             };
-            await PacketIO.SendPacketAsync(ssl, authCodeRequest);
+            await PacketIO.SendPacketAsync(stream, authCodeRequest);
 
             //Add an if statement here and a way to show an error in the UI later
-            await CreateNewUser(name, ssl, passwordHash, authCode);
+            await CreateNewUser(name, stream, passwordHash, authCode);
         }
         else
         {
@@ -98,7 +131,7 @@ public class Client : IAsyncDisposable
                 },
                 Payload = Encoding.UTF8.GetBytes(passwordHash ?? "")
             };
-            await PacketIO.SendPacketAsync(ssl, authPacket);
+            await PacketIO.SendPacketAsync(stream, authPacket);
         }
 
         //===SEND UDP PACKETS (TESTING ONLY)===

--- a/Libraries/ServerApp/Server.cs
+++ b/Libraries/ServerApp/Server.cs
@@ -162,34 +162,40 @@ public class Server : IAsyncDisposable
         client.NoDelay = true;
 
         var net = new NetworkStream(client, ownsSocket: true);
-        var ssl = new SslStream(net, leaveInnerStreamOpen: false);
-        //Try to load, if it throws, then fallback to non-SSL
-        try {
-            X509Certificate2 cert = LoadServerCertificate();
+        Stream stream = net;
+
+        try
+        {
+            var cert = LoadServerCertificate();
+            var ssl = new SslStream(net, leaveInnerStreamOpen: false);
+
+            await ssl.AuthenticateAsServerAsync(
+                serverCertificate: cert,
+                clientCertificateRequired: false,
+                enabledSslProtocols: SslProtocols.Tls12 | SslProtocols.Tls13,
+                checkCertificateRevocation: true
+            );
+
+            stream = ssl;
+            Notification?.Invoke(NotificationType.Info, "SSL certificate loaded successfully. Using encrypted connection.");
         }
-        catch (InvalidOperationException e) {
-            Notification?.Invoke(NotificationType.Warning, 
-            "WARNING: SSL certificate is not present. \
-            Ignore this if you intend to use it unencrypted, \
-            otherwise refer to the README for instructions on setting up a dev certificate.");
+        catch (InvalidOperationException)
+        {
+            Notification?.Invoke(NotificationType.Warning,
+                "WARNING: SSL certificate is not present. " +
+                "Ignore this if you intend to use it unencrypted, otherwise refer to the README for instructions on setting up a dev certificate.");
+            stream = net; // Fallback to non-SSL
         }
-        catch (Exception e) {
-            Notification?.Invoke(NotificationType.Error, $"Unknown error encoutnered: {e.Message}. Terminating process.");
-            Notifcation?.Invoke(NotificationType.Warning, "Press any key to close this window.");
-            Console.ReadLine();
-            Environment.Exit(1);
+        catch (Exception e)
+        {
+            Notification?.Invoke(NotificationType.Error, $"Failed to establish SSL: {e.Message}. Falling back to unencrypted connection.");
+            stream = net; // Fallback to non-SSL
         }
 
-        await ssl.AuthenticateAsServerAsync(
-            serverCertificate: cert,
-            clientCertificateRequired: false,
-            enabledSslProtocols: SslProtocols.Tls12 | SslProtocols.Tls13,
-            checkCertificateRevocation: true
-        );
-        _stream = ssl;
+        _stream = stream;
 
         int id = Interlocked.Increment(ref nextID);
-        clients[id] = new Conn(client, ssl);
+        clients[id] = new Conn(client, stream);
         Notification?.Invoke(NotificationType.Info, $"Client #{id} connected.");
         return id;
     }


### PR DESCRIPTION
## Summary
- add server-side fallback to unencrypted connections when certificate loading or SSL setup fails
- allow the client to retry without SSL when negotiation fails, keeping communication functional without certificates
- update client stream usage so authentication and messaging work with either SSL or plain TCP

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6cfbc410832e890a0a4cc4282d7e)