### PR TITLE
Add invite-driven UDP voice setup

### DIFF
--- a/ClientInterfaces/CLI/CLI.cs
+++ b/ClientInterfaces/CLI/CLI.cs
@@ -112,6 +112,10 @@ class CLI
                 }
                 await PacketIO.SendFileAsync(client._stream, localPath!, client.pendingResponses, remoteFilename, saveLocation);
             }
+            else if (line.StartsWith("--voice"))
+            {
+                await client.SendVoiceInviteAsync();
+            }
             else if (line.StartsWith("--"))
             {
                  await client.SendCommandAsync(line[2..]);

--- a/Libraries/ClientApp/Client.cs
+++ b/Libraries/ClientApp/Client.cs
@@ -24,6 +24,9 @@ public class Client : IAsyncDisposable
     private int id = -1;
     private bool userExists = false;
     private string[] commands = Array.Empty<string>();
+    private IPAddress? serverIp;
+    private int serverPort;
+    private Socket? udp;
 
     // === Public Properties ===
     public string Name { get; private set; }
@@ -47,15 +50,11 @@ public class Client : IAsyncDisposable
     public async Task ConnectAsync(string host, int port, string name, string? passwordHash, bool createUser = false, Func<Task<string?>>? requestAuthCode = null, string authCode = "")
     {
         var ip = IPAddress.TryParse(host, out var ipAddr) ? ipAddr : IPAddress.Loopback;
+        serverIp = ip;
+        serverPort = port;
         var socket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
         authFile = "auth.txt";
         await socket.ConnectAsync(new IPEndPoint(ip, port));
-
-
-        //=== UDP Networking TESTING ONLY ===
-        var udp = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-        //The IP and port we want to listen on for UDP packets
-        udp.Bind(new IPEndPoint(IPAddress.Any, 0));
 
         var net = new NetworkStream(socket, ownsSocket: true);
         Stream stream = net;
@@ -105,7 +104,6 @@ public class Client : IAsyncDisposable
         Name = name;
 
         _ = Task.Run(() => ReceiveLoopAsync(stream));
-        _ = Task.Run(() => UdpReceiveLoopAsync(udp));
 
         if (createUser)
         {
@@ -133,20 +131,6 @@ public class Client : IAsyncDisposable
             };
             await PacketIO.SendPacketAsync(stream, authPacket);
         }
-
-        //===SEND UDP PACKETS (TESTING ONLY)===
-        Packet udpPacket = new Packet
-        {
-            ClientID = name,
-            Headers = new Dictionary<string, string>
-            {
-                {"Protocol", "UDP" },
-                {"Type", "Message" }
-            },
-            Payload = Encoding.UTF8.GetBytes("Hello via UDP!")
-        };
-        await StartListening(udp, ip, port);
-        await UdpSendAsync(udp, ip, port, udpPacket);
     }
     public async Task ReceiveLoopAsync(Stream stream)
     {
@@ -174,6 +158,13 @@ public class Client : IAsyncDisposable
                             {
                                 MessageReceived?.Invoke(packet.ClientID, text);
                             }
+                            break;
+                        case ("VoiceAccepted"):
+                            Notification?.Invoke(NotificationType.Info, "Voice invite accepted. Starting UDP connection.");
+                            await StartUdpConnectionAsync();
+                            break;
+                        case ("VoiceInviteExpired"):
+                            Notification?.Invoke(NotificationType.Warning, "Voice invite expired before it was accepted.");
                             break;
                         case ("Whisper"):
                             WhisperReceived?.Invoke(packet.ClientID, text);
@@ -274,6 +265,45 @@ public class Client : IAsyncDisposable
         MessageReceived?.Invoke("System", "Sending UDP packet.");
         IPEndPoint remoteEndPoint = new IPEndPoint(ip, port);
         await PacketIO.SendPacketToAsyncUdp(udp, packet, remoteEndPoint);
+    }
+
+    public async Task SendVoiceInviteAsync()
+    {
+        if (_stream is null) throw new InvalidOperationException("Not connected.");
+
+        await PacketIO.SendPacketAsync(_stream, new Packet
+        {
+            ClientID = Name,
+            Headers = new Dictionary<string, string> { { "Type", "VoiceInvite" } },
+            Payload = Array.Empty<byte>()
+        });
+    }
+
+    private async Task StartUdpConnectionAsync()
+    {
+        if (udp != null || serverIp is null)
+        {
+            return;
+        }
+
+        udp = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        udp.Bind(new IPEndPoint(IPAddress.Any, 0));
+
+        _ = Task.Run(() => UdpReceiveLoopAsync(udp));
+
+        Packet udpPacket = new Packet
+        {
+            ClientID = Name,
+            Headers = new Dictionary<string, string>
+            {
+                {"Protocol", "UDP" },
+                {"Type", "Message" }
+            },
+            Payload = Encoding.UTF8.GetBytes("Hello via UDP!")
+        };
+
+        await StartListening(udp, serverIp, serverPort);
+        await UdpSendAsync(udp, serverIp, serverPort, udpPacket);
     }
 
     // === Client-Exclusive Messaging Functions

--- a/Libraries/ServerApp/Server.cs
+++ b/Libraries/ServerApp/Server.cs
@@ -9,6 +9,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 
 namespace Client_Server;
 public class Server : IAsyncDisposable
@@ -50,6 +51,11 @@ public class Server : IAsyncDisposable
     private static int nextID = 0;
     private static readonly string[] commands = { "help", "whisper", "w" };
     private static readonly byte[] cmdJson = JsonSerializer.SerializeToUtf8Bytes(commands, CommonJsonContext.Default.StringArray);
+    private IPAddress? listeningIp;
+    private int listeningPort = 11111;
+    private Socket? udp;
+    private int? pendingVoiceClientId;
+    private CancellationTokenSource? voiceInviteCts;
 
     // === Events and Actions ===
     public event Action<string, string>? MessageReceived;   // (from, text)
@@ -98,17 +104,13 @@ public class Server : IAsyncDisposable
                 throw;
             }
         }
-        IPEndPoint localEndPoint = new IPEndPoint(ipAddr, 11111);
+        listeningIp = ipAddr;
+        listeningPort = 11111;
+        IPEndPoint localEndPoint = new IPEndPoint(ipAddr, listeningPort);
         //Create TCP Socket
         listener = new Socket(ipAddr.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
         listener.Bind(localEndPoint);
         listener.Listen(10);
-
-        //=== UDP Networking TESTING ONLY ===
-        var udp = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-        //The IP and port we want to listen on for UDP packets
-        udp.Bind(new IPEndPoint(ipAddr, 11111));
-        _ = Task.Run(() => UdpReceiveLoopAsync(udp));
     }
 
     
@@ -130,6 +132,18 @@ public class Server : IAsyncDisposable
         {
             try { listener.Close(); } catch { }
         }
+    }
+
+    private void StartUdpListenerIfNeeded()
+    {
+        if (udp != null || listeningIp is null)
+        {
+            return;
+        }
+
+        udp = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        udp.Bind(new IPEndPoint(listeningIp, listeningPort));
+        _ = Task.Run(() => UdpReceiveLoopAsync(udp));
     }
 
     public async Task UdpReceiveLoopAsync(Socket udp)
@@ -342,10 +356,47 @@ public class Server : IAsyncDisposable
                         await PacketIO.SendPacketAsync(conn.io, reply);
                         return true;
                 }
+            case "VoiceInvite":
+                Notification?.Invoke(NotificationType.Info, $"Received voice invite from client {id}.");
+                pendingVoiceClientId = id;
+                voiceInviteCts?.Cancel();
+                voiceInviteCts = new CancellationTokenSource();
+                var cts = voiceInviteCts;
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromMinutes(3), cts.Token);
+                        if (cts.IsCancellationRequested || pendingVoiceClientId != id)
+                        {
+                            return;
+                        }
+
+                        pendingVoiceClientId = null;
+                        voiceInviteCts = null;
+                        var expirePacket = new Packet
+                        {
+                            ClientID = "Server",
+                            Headers = new Dictionary<string, string> { { "Type", "VoiceInviteExpired" } },
+                            Payload = Array.Empty<byte>()
+                        };
+
+                        if (clients.TryGetValue(id, out var inviteConn))
+                        {
+                            await PacketIO.SendPacketAsync(inviteConn.io, expirePacket);
+                        }
+
+                        Notification?.Invoke(NotificationType.Warning, "Voice invite expired after 3 minutes.");
+                    }
+                    catch (TaskCanceledException)
+                    {
+                    }
+                });
+                return true;
             case "Ack":
                 Notification?.Invoke(NotificationType.Info, $"Received ACK from client {id}.");
                 //Sets the client's name
-                names[clientID] = id; 
+                names[clientID] = id;
                 return true;
             case "Pos":
                 //Position update packet
@@ -611,7 +662,7 @@ public class Server : IAsyncDisposable
            var parts = line[2..].Split(' ');
            var cmd = parts[0];
            var args = parts.Skip(1).ToArray();
-           switch (cmd)
+            switch (cmd)
             {
                 case "setSaveDir":
                     if (args.Length != 1)
@@ -626,6 +677,36 @@ public class Server : IAsyncDisposable
                 case "file":
                     //skip verification for now
                     await PacketIO.SendFileAsync(_stream, args[0], pendingResponses);
+                    return;
+                case "accept":
+                    if (pendingVoiceClientId is null)
+                    {
+                        Notification?.Invoke(NotificationType.Info, "No pending voice invite to accept.");
+                        return;
+                    }
+
+                    var inviteId = pendingVoiceClientId.Value;
+                    pendingVoiceClientId = null;
+                    voiceInviteCts?.Cancel();
+                    voiceInviteCts = null;
+
+                    if (clients.TryGetValue(inviteId, out var inviteConn))
+                    {
+                        var acceptPacket = new Packet
+                        {
+                            ClientID = "Server",
+                            Headers = new Dictionary<string, string> { { "Type", "VoiceAccepted" } },
+                            Payload = Array.Empty<byte>()
+                        };
+
+                        await PacketIO.SendPacketAsync(inviteConn.io, acceptPacket);
+                        StartUdpListenerIfNeeded();
+                        Notification?.Invoke(NotificationType.Info, "Voice invite accepted. UDP listener started.");
+                    }
+                    else
+                    {
+                        Notification?.Invoke(NotificationType.Warning, "Client disconnected before invite could be accepted.");
+                    }
                     return;
                 default:
                     Notification?.Invoke(NotificationType.Info, "Unknown command.");


### PR DESCRIPTION
## Summary
- delay UDP voice initialization until after a successful TCP invite/accept handshake
- add a client --voice command that sends a TCP invite and starts UDP only after acceptance
- add server-side invite handling with a 3-minute timeout and an --accept command that starts UDP listening

## Testing
- Not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692725958b64832eabf9979eb626a17b)