### PR TITLE
Fix audio clicking by sending only audio frames

### DIFF
--- a/Libraries/ClientApp/Client.cs
+++ b/Libraries/ClientApp/Client.cs
@@ -392,16 +392,6 @@ public class Client : IAsyncDisposable
             {
                 if (!rec.TryDequeue(out var frame) || frame is null)
                 {
-                    var packet = new Packet
-                    {
-                        ClientID = Name,
-                        Headers = new Dictionary<string, string>
-                        {
-                            { "Type", "Message" }
-                        },
-                        Payload = Encoding.UTF8.GetBytes("No audio frame available yet")
-                    };
-                    PacketIO.SendPacketToAsyncUdp(udp, packet, remote);
                     Thread.Sleep(1);
                     continue;
                 }

--- a/Libraries/ServerApp/Server.cs
+++ b/Libraries/ServerApp/Server.cs
@@ -158,6 +158,12 @@ public class Server : IAsyncDisposable
             var result = await udp.ReceiveFromAsync(buf, SocketFlags.None, remote);
             Packet packet = PacketIO.DeserializeForUdp(buf.AsSpan(0, result.ReceivedBytes));
             var from = (IPEndPoint)result.RemoteEndPoint;
+            if (!packet.Headers.TryGetValue("Type", out var type) || type != "Audio")
+            {
+                Notification?.Invoke(NotificationType.Info, $"Ignoring non-audio UDP packet from {from}");
+                continue;
+            }
+
             _player!.AddFrame(packet.Payload, 0, packet.Payload.Length);
         }
     }


### PR DESCRIPTION
## Summary
- stop sending placeholder UDP packets when no microphone audio frames are available
- ignore non-audio UDP packets on the server before they reach the playback buffer

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927868196c0832e8853f8699fd122e2)