### PR TITLE
Add Opus compression for voice chat audio

### DIFF
--- a/Libraries/ClientApp/VoiceSessionManager.cs
+++ b/Libraries/ClientApp/VoiceSessionManager.cs
@@ -13,6 +13,7 @@ internal class VoiceSessionManager {
     internal readonly object udpLock = new();
     internal bool playbackWarningSent = false;
     internal AudioPlayer? _player;
+    internal OpusCodec? _codec;
     internal event Action<NotificationType, string> Notification;
     internal string Name;
     internal string PlatformName;
@@ -35,6 +36,8 @@ internal class VoiceSessionManager {
         Notification?.Invoke(NotificationType.Info, "Starting microphone capture...");
         var rec = new MicRecorder(frameMs: 10);
         rec.Start();
+        var codec = EnsureCodec();
+        var encodedBuffer = new byte[codec.MaxPacketSize];
         var remote = new IPEndPoint(ip, port);
 
         // === Sequencing ===
@@ -58,6 +61,10 @@ internal class VoiceSessionManager {
                     var slice = new byte[take];
                     Buffer.BlockCopy(frame, offset, slice, 0, take);
 
+                    int encodedLength = codec.Encode(slice, encodedBuffer);
+                    var payload = new byte[encodedLength];
+                    Buffer.BlockCopy(encodedBuffer, 0, payload, 0, encodedLength);
+
                     // 3) Add minimal sequencing metadata (headers) for VoIP
                     var audio = new Packet {
                         ClientID = Name, // your ID string
@@ -67,9 +74,9 @@ internal class VoiceSessionManager {
                             { "Protocol", "UDP" },
                             { "Seq", seq.ToString() },
                             { "Ts",  timestampSamples.ToString() }, // samples @ 48k
-                            { "Fmt", "PCM16_48k_Mono" }
+                            { "Fmt", codec.FormatLabel }
                         },
-                        Payload = slice
+                        Payload = payload
                     };
                     PacketIO.SendPacketToAsyncUdp(udp, audio, remote);
 
@@ -103,7 +110,9 @@ internal class VoiceSessionManager {
                         }
                         if (PlatformName == "Windows") {
                             EnsurePlayer();
-                            _player?.AddFrame(packet.Payload, 0, packet.Payload.Length);
+                            var codec = EnsureCodec();
+                            var pcm = codec.Decode(packet.Payload);
+                            _player?.AddFrame(pcm, 0, pcm.Length);
                         }
                         else if (!playbackWarningSent) {
                             playbackWarningSent = true;
@@ -203,5 +212,10 @@ internal class VoiceSessionManager {
         }
 
         _player = new AudioPlayer(latencyMs: 100, jitterMs: 600);
+    }
+
+    internal OpusCodec EnsureCodec() {
+        _codec ??= new OpusCodec(frameMs: 10, bitrate: 32000);
+        return _codec;
     }
 }

--- a/Libraries/Common/Audio/OpusCodec.cs
+++ b/Libraries/Common/Audio/OpusCodec.cs
@@ -1,0 +1,55 @@
+using Concentus.Enums;
+using Concentus.Structs;
+using System.Runtime.InteropServices;
+
+namespace Common.Audio;
+
+public sealed class OpusCodec {
+    private const int SampleRate = 48000;
+    private const int Channels = 1;
+    private const int BytesPerSample = 2;
+    private const int DefaultMaxPacketBytes = 1275;
+
+    private readonly OpusEncoder encoder;
+    private readonly OpusDecoder decoder;
+    private readonly short[] pcmBuffer;
+    private readonly short[] decodeBuffer;
+
+    public int FrameSamples { get; }
+    public int MaxPacketSize { get; }
+    public int Bitrate { get; }
+    public string FormatLabel { get; }
+
+    public OpusCodec(int frameMs = 10, int bitrate = 32000, int? maxPacketBytes = null) {
+        FrameSamples = SampleRate * frameMs / 1000;
+        Bitrate = bitrate;
+        MaxPacketSize = maxPacketBytes ?? DefaultMaxPacketBytes;
+        FormatLabel = $"OPUS_{SampleRate / 1000}k_Mono_{bitrate / 1000}kbps";
+
+        encoder = OpusEncoder.Create(SampleRate, Channels, OpusApplication.OPUS_APPLICATION_VOIP);
+        encoder.Bitrate = bitrate;
+
+        decoder = OpusDecoder.Create(SampleRate, Channels);
+
+        pcmBuffer = new short[FrameSamples];
+        decodeBuffer = new short[FrameSamples];
+    }
+
+    public int Encode(ReadOnlySpan<byte> pcmBytes, byte[] output) {
+        if (pcmBytes.Length != FrameSamples * BytesPerSample) {
+            throw new ArgumentException($"Expected {FrameSamples * BytesPerSample} bytes for {FrameSamples} samples.", nameof(pcmBytes));
+        }
+        if (output.Length < MaxPacketSize) {
+            throw new ArgumentException($"Output buffer must be at least {MaxPacketSize} bytes.", nameof(output));
+        }
+
+        MemoryMarshal.Cast<byte, short>(pcmBytes).CopyTo(pcmBuffer);
+        return encoder.Encode(pcmBuffer, 0, FrameSamples, output, 0, output.Length);
+    }
+
+    public byte[] Decode(ReadOnlySpan<byte> encoded) {
+        int samples = decoder.Decode(encoded.ToArray(), 0, encoded.Length, decodeBuffer, 0, FrameSamples, false);
+        var pcmBytes = MemoryMarshal.AsBytes(decodeBuffer.AsSpan(0, samples));
+        return pcmBytes.ToArray();
+    }
+}

--- a/Libraries/Common/Common.csproj
+++ b/Libraries/Common/Common.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Concentus" Version="1.1.7" />
     <PackageReference Include="OpenTK.Audio.OpenAL" Version="4.9.4" />
     <PackageReference Include="Syroot.Windows.IO.KnownFolders" Version="1.3.0" />
       <None Include="runtimes\win-x64\native\openal32.dll" Link="openal32.dll">

--- a/Libraries/ServerApp/VoiceChatManager.cs
+++ b/Libraries/ServerApp/VoiceChatManager.cs
@@ -19,6 +19,7 @@ internal class VoiceChatManager {
     internal AudioPlayer? _player;
     internal MicRecorder? _mic;
     internal Thread? micSenderThread;
+    internal OpusCodec? _codec;
     internal bool disableServerMic;
     internal readonly IPAddress? listeningIp;
     internal readonly int listeningPort;
@@ -75,7 +76,9 @@ internal class VoiceChatManager {
 
                 if (voiceParticipants.ContainsKey(0) && serverPlatform == "Windows") {
                     EnsureServerPlayer();
-                    _player?.AddFrame(packet.Payload, 0, packet.Payload.Length);
+                    var codec = EnsureCodec();
+                    var pcm = codec.Decode(packet.Payload);
+                    _player?.AddFrame(pcm, 0, pcm.Length);
                 }
             }
             catch (ObjectDisposedException) {
@@ -139,6 +142,9 @@ internal class VoiceChatManager {
             const int samplesPer10ms = 480;
             const int maxFrameBytes = samplesPer10ms * bytesPerSample;
 
+            var codec = EnsureCodec();
+            var encodedBuffer = new byte[codec.MaxPacketSize];
+
             uint seq = 0;
             int timestampSamples = 0;
 
@@ -154,6 +160,10 @@ internal class VoiceChatManager {
                     var slice = new byte[take];
                     Buffer.BlockCopy(frame, offset, slice, 0, take);
 
+                    int encodedLength = codec.Encode(slice, encodedBuffer);
+                    var payload = new byte[encodedLength];
+                    Buffer.BlockCopy(encodedBuffer, 0, payload, 0, encodedLength);
+
                     var packet = new Packet {
                         ClientID = Name,
                         Headers = new Dictionary<string, string>
@@ -162,9 +172,9 @@ internal class VoiceChatManager {
                             { "Protocol", "UDP" },
                             { "Seq", seq.ToString() },
                             { "Ts", timestampSamples.ToString() },
-                            { "Fmt", "PCM16_48k_Mono" }
+                            { "Fmt", codec.FormatLabel }
                         },
-                        Payload = slice
+                        Payload = payload
                     };
 
                     var endpoints = udpClients
@@ -201,6 +211,11 @@ internal class VoiceChatManager {
         }
 
         _player = new AudioPlayer(latencyMs: 100, jitterMs: 600);
+    }
+
+    internal OpusCodec EnsureCodec() {
+        _codec ??= new OpusCodec(frameMs: 10, bitrate: 32000);
+        return _codec;
     }
 
     internal void CloseUdpConnection() {


### PR DESCRIPTION
## Summary
- add a shared Opus codec helper and Concentus dependency to support compressed audio
- encode outgoing voice frames at 32 kbps and decode incoming audio on both client and server voice paths

## Testing
- dotnet build ClientServerProject.slnx *(fails: dotnet not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9c1a88f4832e8d02196eb1c8e1c9)